### PR TITLE
feat(tauri): disable background throttling for window

### DIFF
--- a/apps/whispering/src-tauri/tauri.conf.json
+++ b/apps/whispering/src-tauri/tauri.conf.json
@@ -60,7 +60,8 @@
 				"height": 700,
 				"minHeight": 84,
 				"minWidth": 72,
-				"transparent": true
+				"transparent": true,
+				"backgroundThrottling": "disabled"
 			}
 		],
 		"security": {


### PR DESCRIPTION
Prevents the OS from throttling the app when it loses focus, ensuring recording and processing continues uninterrupted in the background.