### PR TITLE
fix(qwen3-asr): kill orphaned daemons on startup

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -385,7 +385,11 @@ pub async fn run() {
         .manage(AppData::new());
 
     #[cfg(target_os = "macos")]
-    { builder = builder.manage(QwenASRState(std::sync::Arc::new(std::sync::Mutex::new(None)))); }
+    {
+        // Kill orphaned daemons from previous crash/force-quit before registering state.
+        let _ = std::process::Command::new("pkill").args(["-f", "qwen3-asr-cli"]).output();
+        builder = builder.manage(QwenASRState(std::sync::Arc::new(std::sync::Mutex::new(None))));
+    }
 
     #[cfg(desktop)]
     {


### PR DESCRIPTION
Crashes and force-quits leave qwen3-asr-cli processes alive since the Rust Drop impl never runs. On the next launch, a new daemon spawns alongside the orphans — each holding ~1GB RAM from the loaded MLX model, causing system-wide memory pressure and lag.

A single pkill before state initialization clears any leftover processes. Normal shutdowns are unaffected since Drop already handles those cleanly.