### PR TITLE
fix(qwen3-asr): preflight guards for missing model and unsupported macOS

### DIFF
--- a/apps/whispering/src/lib/query/notify.ts
+++ b/apps/whispering/src/lib/query/notify.ts
@@ -19,8 +19,13 @@ const createNotifyMutation = (
 		) => {
 			const fullOptions: UnifiedNotificationOptions = { ...options, variant };
 
-			// Check if notifications are disabled (except for critical notifications like updates)
-			const isCritical = fullOptions.title?.includes('Update') || fullOptions.persist;
+			// Errors and warnings always show — they indicate something went wrong and require user awareness.
+			// Success/info/loading respect the notifications.enabled setting (ambient noise).
+			const isCritical =
+				variant === 'error' ||
+				variant === 'warning' ||
+				fullOptions.title?.includes('Update') ||
+				fullOptions.persist;
 			if (!settings.value['notifications.enabled'] && !isCritical) {
 				// Still log in dev mode even if notifications are disabled
 				if (dev) {

--- a/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
+++ b/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
@@ -133,6 +133,30 @@ export function createQwen3ASRService() {
 			audioBlob: Blob,
 			options: { outputLanguage: string; modelId: Qwen3ASRModelId },
 		): Promise<Result<string, NoteFluxError>> {
+			try {
+				const ver = await osVersion();
+				if (parseInt(ver.split('.')[0], 10) < 15) {
+					return NoteFluxErr({
+						title: '⚙️ macOS 15+ required',
+						description:
+							'Qwen3-ASR uses MLX Metal shaders that require macOS 15 (Sequoia) or newer. Switch to a cloud transcription service in Settings.',
+					});
+				}
+			} catch {}
+
+			try {
+				const status = await invoke<Qwen3ASRModelStatus>('qwen3_asr_model_status', {
+					modelId: options.modelId,
+				});
+				if (status !== 'downloaded') {
+					return NoteFluxErr({
+						title: '📥 Model not downloaded',
+						description:
+							'The Qwen3-ASR model is not downloaded yet. Go to Settings → Transcription to download it first.',
+					});
+				}
+			} catch {}
+
 			const audioPath = await join(await tempDir(), `qwen3asr_${Date.now()}.wav`);
 
 			const { error: writeError } = await tryAsync({

--- a/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
+++ b/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
@@ -139,7 +139,12 @@ export function createQwen3ASRService() {
 					return NoteFluxErr({
 						title: '⚙️ macOS 15+ required',
 						description:
-							'Qwen3-ASR uses MLX Metal shaders that require macOS 15 (Sequoia) or newer. Switch to a cloud transcription service in Settings.',
+							'Qwen3-ASR requires macOS 15 (Sequoia) or newer. Switch to a cloud transcription service.',
+						action: {
+							href: '/settings/transcription',
+							label: 'Open Settings',
+							type: 'link',
+						},
 					});
 				}
 			} catch {}
@@ -152,7 +157,12 @@ export function createQwen3ASRService() {
 					return NoteFluxErr({
 						title: '📥 Model not downloaded',
 						description:
-							'The Qwen3-ASR model is not downloaded yet. Go to Settings → Transcription to download it first.',
+							'The Qwen3-ASR model needs to be downloaded before use.',
+						action: {
+							href: '/settings/transcription',
+							label: 'Download Model',
+							type: 'link',
+						},
 					});
 				}
 			} catch {}

--- a/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
+++ b/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
@@ -10,6 +10,7 @@ import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 export type Qwen3ASRService = ReturnType<typeof createQwen3ASRService>;
 
 let cachedMacOSMajorVersion: number | null = null;
+const verifiedDownloadedModels = new Set<string>();
 
 export type Qwen3ASRModelStatus = 'downloaded' | 'not_downloaded';
 
@@ -95,7 +96,7 @@ export function createQwen3ASRService() {
 		 * Deletes the cached model weights from disk and shuts down the daemon.
 		 */
 		async deleteModel(modelId: Qwen3ASRModelId): Promise<Result<void, NoteFluxError>> {
-			return tryAsync({
+			const result = await tryAsync({
 				mapErr: (error) =>
 					NoteFluxErr({
 						title: '🗑️ Model delete failed',
@@ -107,6 +108,8 @@ export function createQwen3ASRService() {
 					}),
 				try: () => invoke<void>('delete_qwen3_asr_model', { modelId }),
 			});
+			if (result.data !== undefined) verifiedDownloadedModels.delete(modelId);
+			return result;
 		},
 
 		/**
@@ -153,23 +156,25 @@ export function createQwen3ASRService() {
 				}
 			} catch {}
 
-			try {
-				const status = await invoke<Qwen3ASRModelStatus>('qwen3_asr_model_status', {
-					modelId: options.modelId,
-				});
-				if (status !== 'downloaded') {
-					return NoteFluxErr({
-						title: '📥 Model not downloaded',
-						description:
-							'The Qwen3-ASR model needs to be downloaded before use.',
-						action: {
-							href: '/settings/transcription',
-							label: 'Download Model',
-							type: 'link',
-						},
+			if (!verifiedDownloadedModels.has(options.modelId)) {
+				try {
+					const status = await invoke<Qwen3ASRModelStatus>('qwen3_asr_model_status', {
+						modelId: options.modelId,
 					});
-				}
-			} catch {}
+					if (status !== 'downloaded') {
+						return NoteFluxErr({
+							title: '📥 Model not downloaded',
+							description: 'The Qwen3-ASR model needs to be downloaded before use.',
+							action: {
+								href: '/settings/transcription',
+								label: 'Download Model',
+								type: 'link',
+							},
+						});
+					}
+					verifiedDownloadedModels.add(options.modelId);
+				} catch {}
+			}
 
 			const audioPath = await join(await tempDir(), `qwen3asr_${Date.now()}.wav`);
 

--- a/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
+++ b/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
@@ -9,6 +9,8 @@ import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 
 export type Qwen3ASRService = ReturnType<typeof createQwen3ASRService>;
 
+let cachedMacOSMajorVersion: number | null = null;
+
 export type Qwen3ASRModelStatus = 'downloaded' | 'not_downloaded';
 
 export const QWEN3_ASR_MODELS = [
@@ -134,8 +136,10 @@ export function createQwen3ASRService() {
 			options: { outputLanguage: string; modelId: Qwen3ASRModelId },
 		): Promise<Result<string, NoteFluxError>> {
 			try {
-				const ver = await osVersion();
-				if (parseInt(ver.split('.')[0], 10) < 15) {
+				if (cachedMacOSMajorVersion === null) {
+					cachedMacOSMajorVersion = parseInt((await osVersion()).split('.')[0], 10);
+				}
+				if (cachedMacOSMajorVersion < 15) {
 					return NoteFluxErr({
 						title: '⚙️ macOS 15+ required',
 						description:


### PR DESCRIPTION
When a user has Qwen3-ASR selected but the model isn't downloaded — or is running macOS < 15 — the daemon crashes immediately with a raw Swift error message like "Sidecar startup error: ..." which gives no actionable guidance.

This adds two fail-fast checks at the top of `transcribe()`, before any temp file I/O:

1. macOS version check: returns "macOS 15+ required, switch to a cloud service in Settings" immediately if below Sequoia.
2. Model status check: returns "Model not downloaded, go to Settings → Transcription to download it first" immediately instead of hitting the daemon.

Both errors surface as toast notifications via the existing `NoteFluxError` pipeline. No daemon is spawned, no temp audio is written, no 60-second wait.

Covers the main stuck-user scenario: settings persisting across reinstalls with Qwen3-ASR selected but model cache cleared.