### PR TITLE
perf(recorder): reuse CPAL stream and eliminate blocking work on Fn press

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -470,6 +470,35 @@ pub async fn run() {
 
     let mut app = builder
         .setup(|app| {
+            // Prevent macOS App Nap so the process stays responsive after idle.
+            // Without this, macOS throttles the event loop after ~3 minutes,
+            // causing a noticeable delay on the first Fn press after a pause.
+            #[cfg(target_os = "macos")]
+            {
+                use objc::class;
+                unsafe {
+                    let process_info: *mut objc::runtime::Object =
+                        msg_send![class!(NSProcessInfo), processInfo];
+                    let reason_cstr = std::ffi::CString::new(
+                        "Must respond instantly to global shortcut"
+                    ).unwrap();
+                    let reason: *mut objc::runtime::Object = msg_send![
+                        class!(NSString),
+                        stringWithUTF8String: reason_cstr.as_ptr()
+                    ];
+                    // NSActivityUserInitiatedAllowingIdleSystemSleep = 0x00FFFFFF
+                    // Prevents App Nap without blocking system sleep (lid close works normally).
+                    let _activity: *mut objc::runtime::Object = msg_send![
+                        process_info,
+                        beginActivityWithOptions: 0x00FFFFFFu64
+                        reason: reason
+                    ];
+                    // Intentionally leaked — activity token must live for the app lifetime.
+                    // Dropping it would re-enable App Nap.
+                    std::mem::forget(_activity);
+                }
+            }
+
             println!("[FnShortcut] Initializing Fn shortcut manager...");
 
             // Initialize Fn shortcut manager based on platform

--- a/apps/whispering/src-tauri/src/recorder/recorder.rs
+++ b/apps/whispering/src-tauri/src/recorder/recorder.rs
@@ -82,8 +82,9 @@ impl Drop for StreamHolder {
 /// Simplified recorder state
 pub struct RecorderState {
     stream_holder: Option<StreamHolder>,
-    writer: Option<Arc<Mutex<WavWriter>>>,
+    writer: Arc<Mutex<Option<WavWriter>>>,
     is_recording: Arc<AtomicBool>,
+    current_device: Option<String>,
     sample_rate: u32,
     channels: u16,
     file_path: Option<PathBuf>,
@@ -93,8 +94,9 @@ impl RecorderState {
     pub fn new() -> Self {
         Self {
             stream_holder: None,
-            writer: None,
+            writer: Arc::new(Mutex::new(None)),
             is_recording: Arc::new(AtomicBool::new(false)),
+            current_device: None,
             sample_rate: 0,
             channels: 0,
             file_path: None,
@@ -113,7 +115,9 @@ impl RecorderState {
         Ok(devices)
     }
 
-    /// Initialize recording session - creates stream and WAV writer
+    /// Initialize recording session.
+    /// Reuses the existing CPAL stream if the device hasn't changed — only swaps
+    /// the WavWriter. Rebuilds the stream from scratch on first call or device change.
     pub fn init_session(
         &mut self,
         device_name: String,
@@ -121,68 +125,78 @@ impl RecorderState {
         recording_id: String,
         preferred_sample_rate: Option<u32>,
     ) -> Result<()> {
-        // Clean up any existing session
-        self.close_session()?;
-
-        // Create file path
         let file_path = output_folder.join(format!("{}.wav", recording_id));
 
-        // Find the device
-        let host = cpal::default_host();
-        let device = find_device(&host, &device_name)?;
+        let can_reuse = self.stream_holder.is_some()
+            && self.current_device.as_deref() == Some(&device_name);
 
-        // Get optimal config for voice with optional preferred sample rate
-        let config = get_optimal_config(&device, preferred_sample_rate)?;
-        let sample_format = config.sample_format();
-        let sample_rate = config.sample_rate().0;
-        let channels = config.channels();
+        if !can_reuse {
+            // Expensive path: build a new stream
+            self.close_session()?;
 
-        // Create WAV writer
-        let writer = WavWriter::new(file_path.clone(), sample_rate, channels)
+            let host = cpal::default_host();
+            let device = find_device(&host, &device_name)?;
+            let config = get_optimal_config(&device, preferred_sample_rate)?;
+            let sample_format = config.sample_format();
+            let sample_rate = config.sample_rate().0;
+            let channels = config.channels();
+
+            let stream_config = cpal::StreamConfig {
+                channels,
+                sample_rate: cpal::SampleRate(sample_rate),
+                buffer_size: cpal::BufferSize::Fixed(256),
+            };
+
+            self.is_recording = Arc::new(AtomicBool::new(false));
+            let is_recording = self.is_recording.clone();
+            let is_recording_clone = is_recording.clone();
+            let writer = self.writer.clone();
+
+            let stream_holder = StreamHolder::new(
+                move || match sample_format {
+                    SampleFormat::F32 => {
+                        build_stream_f32(&device, &stream_config, is_recording_clone, writer)
+                    }
+                    SampleFormat::I16 => {
+                        build_stream_i16(&device, &stream_config, is_recording_clone, writer)
+                    }
+                    SampleFormat::U16 => {
+                        build_stream_u16(&device, &stream_config, is_recording_clone, writer)
+                    }
+                    _ => Err("Unsupported sample format".to_string()),
+                },
+                is_recording,
+            )?;
+
+            self.stream_holder = Some(stream_holder);
+            self.sample_rate = sample_rate;
+            self.channels = channels;
+            self.current_device = Some(device_name);
+
+            info!(
+                "Recording stream built: {} Hz, {} channels",
+                self.sample_rate, self.channels
+            );
+        }
+
+        // Cheap path (always): swap in a fresh WavWriter for this recording
+        let new_writer = WavWriter::new(file_path.clone(), self.sample_rate, self.channels)
             .map_err(|e| format!("Failed to create WAV file: {}", e))?;
-        let writer = Arc::new(Mutex::new(writer));
 
-        // Create stream config
-        let stream_config = cpal::StreamConfig {
-            channels,
-            sample_rate: cpal::SampleRate(sample_rate),
-            buffer_size: cpal::BufferSize::Default,
-        };
+        {
+            let mut w = self
+                .writer
+                .lock()
+                .map_err(|e| format!("Lock error: {}", e))?;
+            *w = Some(new_writer);
+        }
 
-        // Create fresh recording flag
-        self.is_recording = Arc::new(AtomicBool::new(false));
-        let is_recording = self.is_recording.clone();
-
-        // Create the stream holder with a closure that builds the stream
-        let writer_clone = writer.clone();
-        let is_recording_clone = is_recording.clone();
-
-        let stream_holder = StreamHolder::new(
-            move || match sample_format {
-                SampleFormat::F32 => {
-                    build_stream_f32(&device, &stream_config, is_recording_clone, writer_clone)
-                }
-                SampleFormat::I16 => {
-                    build_stream_i16(&device, &stream_config, is_recording_clone, writer_clone)
-                }
-                SampleFormat::U16 => {
-                    build_stream_u16(&device, &stream_config, is_recording_clone, writer_clone)
-                }
-                _ => Err("Unsupported sample format".to_string()),
-            },
-            is_recording,
-        )?;
-
-        // Store everything
-        self.stream_holder = Some(stream_holder);
-        self.writer = Some(writer);
-        self.sample_rate = sample_rate;
-        self.channels = channels;
+        self.is_recording.store(false, Ordering::Release);
         self.file_path = Some(file_path);
 
         info!(
-            "Recording session initialized: {} Hz, {} channels, file: {:?}",
-            sample_rate, channels, self.file_path
+            "Recording session ready: file: {:?} (stream reused: {})",
+            self.file_path, can_reuse
         );
 
         Ok(())
@@ -200,21 +214,25 @@ impl RecorderState {
         Ok(())
     }
 
-    /// Stop recording - return file info
+    /// Stop recording - finalize WAV, leave stream alive for next Fn press
     pub fn stop_recording(&mut self) -> Result<AudioRecording> {
-        // Stop recording flag first
         self.is_recording.store(false, Ordering::Release);
 
-        // Finalize the WAV file and get metadata
-        let (sample_rate, channels, duration) = if let Some(writer) = &self.writer {
-            let mut w = writer
+        let (sample_rate, channels, duration) = {
+            let mut w = self
+                .writer
                 .lock()
-                .map_err(|e| format!("Failed to lock writer: {}", e))?;
-            w.finalize()
-                .map_err(|e| format!("Failed to finalize WAV: {}", e))?;
-            w.get_metadata()
-        } else {
-            (self.sample_rate, self.channels, 0.0)
+                .map_err(|e| format!("Lock error: {}", e))?;
+            if let Some(ref mut writer) = *w {
+                writer
+                    .finalize()
+                    .map_err(|e| format!("Failed to finalize WAV: {}", e))?;
+                let meta = writer.get_metadata();
+                *w = None;
+                meta
+            } else {
+                (self.sample_rate, self.channels, 0.0)
+            }
         };
 
         let file_path = self
@@ -225,7 +243,7 @@ impl RecorderState {
         info!("Recording stopped: {:.2}s, file: {:?}", duration, file_path);
 
         Ok(AudioRecording {
-            audio_data: Vec::new(), // Empty for file-based recording
+            audio_data: Vec::new(),
             sample_rate,
             channels,
             duration_seconds: duration,
@@ -233,44 +251,50 @@ impl RecorderState {
         })
     }
 
-    /// Cancel recording - stop and delete the file
+    /// Cancel recording - clear writer and delete file, leave stream alive
     pub fn cancel_recording(&mut self) -> Result<()> {
-        // Stop recording
         self.is_recording.store(false, Ordering::Release);
 
-        // Delete the file if it exists
-        if let Some(file_path) = &self.file_path {
-            std::fs::remove_file(file_path).ok(); // Ignore errors
-            debug!("Deleted recording file: {:?}", file_path);
+        {
+            let mut w = self
+                .writer
+                .lock()
+                .map_err(|e| format!("Lock error: {}", e))?;
+            *w = None; // drops WavWriter (Drop finalizes headers), then file is deleted below
         }
 
-        // Clear the session
-        self.close_session()?;
+        if let Some(file_path) = &self.file_path {
+            std::fs::remove_file(file_path).ok();
+            debug!("Deleted recording file: {:?}", file_path);
+        }
+        self.file_path = None;
 
         Ok(())
     }
 
-    /// Close the recording session
+    /// Close the recording session - kills stream. Called on device change or app quit.
     pub fn close_session(&mut self) -> Result<()> {
-        // Stop recording if active
         self.is_recording.store(false, Ordering::Release);
 
-        // Stop and drop the stream holder
         if let Some(mut holder) = self.stream_holder.take() {
             holder.stop();
         }
 
-        // Finalize and drop the writer
-        if let Some(writer) = self.writer.take() {
-            if let Ok(mut w) = writer.lock() {
-                let _ = w.finalize(); // Ignore errors during cleanup
+        {
+            let mut w = self
+                .writer
+                .lock()
+                .map_err(|e| format!("Lock error: {}", e))?;
+            if let Some(ref mut writer) = *w {
+                let _ = writer.finalize();
             }
+            *w = None;
         }
 
-        // Clear state
         self.file_path = None;
         self.sample_rate = 0;
         self.channels = 0;
+        self.current_device = None;
 
         debug!("Recording session closed");
         Ok(())
@@ -292,14 +316,12 @@ impl RecorderState {
 
 /// Find a recording device by name
 fn find_device(host: &cpal::Host, device_name: &str) -> Result<Device> {
-    // Handle "default" device
     if device_name.to_lowercase() == "default" {
         return host
             .default_input_device()
             .ok_or_else(|| "No default input device available".to_string());
     }
 
-    // Find specific device
     let devices: Vec<_> = host.input_devices().map_err(|e| e.to_string())?.collect();
 
     for device in devices {
@@ -318,7 +340,6 @@ fn get_optimal_config(
     device: &Device,
     preferred_sample_rate: Option<u32>,
 ) -> Result<cpal::SupportedStreamConfig> {
-    // Use preferred sample rate or default to 16kHz for voice
     let target_sample_rate = preferred_sample_rate.unwrap_or(16000);
 
     let configs: Vec<_> = device
@@ -330,7 +351,6 @@ fn get_optimal_config(
         return Err("No supported input configurations".to_string());
     }
 
-    // Try to find mono config with target sample rate
     for config in &configs {
         if config.channels() == 1 {
             let min_rate = config.min_sample_rate().0;
@@ -341,7 +361,6 @@ fn get_optimal_config(
         }
     }
 
-    // Try stereo with target sample rate if mono not available
     for config in &configs {
         let min_rate = config.min_sample_rate().0;
         let max_rate = config.max_sample_rate().0;
@@ -350,17 +369,14 @@ fn get_optimal_config(
         }
     }
 
-    // If target rate not supported, try to find closest rate
     let mut best_config = None;
     let mut best_diff = u32::MAX;
 
     for config in &configs {
-        // Prefer mono
         if config.channels() == 1 {
             let min_rate = config.min_sample_rate().0;
             let max_rate = config.max_sample_rate().0;
 
-            // Find closest supported rate
             let closest_rate = if target_sample_rate < min_rate {
                 min_rate
             } else if target_sample_rate > max_rate {
@@ -377,7 +393,6 @@ fn get_optimal_config(
         }
     }
 
-    // Return best config or fall back to default
     best_config
         .or_else(|| device.default_input_config().ok())
         .ok_or_else(|| "Failed to find suitable audio configuration".to_string())
@@ -388,7 +403,7 @@ fn build_stream_f32(
     device: &Device,
     config: &cpal::StreamConfig,
     is_recording: Arc<AtomicBool>,
-    writer: Arc<Mutex<WavWriter>>,
+    writer: Arc<Mutex<Option<WavWriter>>>,
 ) -> Result<Stream> {
     let err_fn = |err| error!("Audio stream error: {}", err);
 
@@ -398,7 +413,9 @@ fn build_stream_f32(
             move |data: &[f32], _: &_| {
                 if is_recording.load(Ordering::Acquire) {
                     if let Ok(mut w) = writer.lock() {
-                        let _ = w.write_samples_f32(data);
+                        if let Some(ref mut w) = *w {
+                            let _ = w.write_samples_f32(data);
+                        }
                     }
                 }
             },
@@ -407,7 +424,6 @@ fn build_stream_f32(
         )
         .map_err(|e| format!("Failed to build stream: {}", e))?;
 
-    // Start the stream immediately
     stream
         .play()
         .map_err(|e| format!("Failed to start stream: {}", e))?;
@@ -420,7 +436,7 @@ fn build_stream_i16(
     device: &Device,
     config: &cpal::StreamConfig,
     is_recording: Arc<AtomicBool>,
-    writer: Arc<Mutex<WavWriter>>,
+    writer: Arc<Mutex<Option<WavWriter>>>,
 ) -> Result<Stream> {
     let err_fn = |err| error!("Audio stream error: {}", err);
 
@@ -430,7 +446,9 @@ fn build_stream_i16(
             move |data: &[i16], _: &_| {
                 if is_recording.load(Ordering::Acquire) {
                     if let Ok(mut w) = writer.lock() {
-                        let _ = w.write_samples_i16(data);
+                        if let Some(ref mut w) = *w {
+                            let _ = w.write_samples_i16(data);
+                        }
                     }
                 }
             },
@@ -439,7 +457,6 @@ fn build_stream_i16(
         )
         .map_err(|e| format!("Failed to build stream: {}", e))?;
 
-    // Start the stream immediately
     stream
         .play()
         .map_err(|e| format!("Failed to start stream: {}", e))?;
@@ -452,7 +469,7 @@ fn build_stream_u16(
     device: &Device,
     config: &cpal::StreamConfig,
     is_recording: Arc<AtomicBool>,
-    writer: Arc<Mutex<WavWriter>>,
+    writer: Arc<Mutex<Option<WavWriter>>>,
 ) -> Result<Stream> {
     let err_fn = |err| error!("Audio stream error: {}", err);
 
@@ -462,7 +479,9 @@ fn build_stream_u16(
             move |data: &[u16], _: &_| {
                 if is_recording.load(Ordering::Acquire) {
                     if let Ok(mut w) = writer.lock() {
-                        let _ = w.write_samples_u16(data);
+                        if let Some(ref mut w) = *w {
+                            let _ = w.write_samples_u16(data);
+                        }
                     }
                 }
             },
@@ -471,7 +490,6 @@ fn build_stream_u16(
         )
         .map_err(|e| format!("Failed to build stream: {}", e))?;
 
-    // Start the stream immediately
     stream
         .play()
         .map_err(|e| format!("Failed to start stream: {}", e))?;

--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -85,8 +85,11 @@ export const commandCallbacks = commands.reduce<CommandCallbacks>(
 
 // Track local state for instant feedback without backend roundtrip
 let isRecordingOrStarting = false;
-// Track pending start operation to ensure we don't try to stop before start finishes
-let pendingStartPromise: Promise<any> | null = null;
+// Track pending start operation to ensure we don't try to stop before start finishes.
+// Note: .execute() never throws — errors come back as { error } in the Result.
+let pendingStartPromise: ReturnType<
+	typeof rpc.commands.startManualRecording.execute
+> | null = null;
 
 // Global shortcut callbacks - these pass 'global-shortcut' as the initiation method
 export const globalCommandCallbacks: CommandCallbacks = {
@@ -99,15 +102,13 @@ export const globalCommandCallbacks: CommandCallbacks = {
 			// SAFETY: If we are still starting (e.g. quick tap), wait for start to finish first
 			// This prevents the "stop before start" race condition
 			if (pendingStartPromise) {
-				try {
-					await pendingStartPromise;
-				} catch (error) {
-					// If start failed, we can't stop a non-existent recording
-					console.error('Start failed, cannot stop:', error);
-					pendingStartPromise = null;
+				const { error: startError } = await pendingStartPromise;
+				pendingStartPromise = null;
+				if (startError) {
+					// Start failed — there is no recording to stop
+					console.error('Start failed, cannot stop:', startError);
 					return;
 				}
-				pendingStartPromise = null;
 			}
 
 			// Now safely stop the recording
@@ -122,18 +123,17 @@ export const globalCommandCallbacks: CommandCallbacks = {
 				initiatedVia: 'global-shortcut',
 			});
 
-			try {
-				await pendingStartPromise;
-			} catch (error) {
-				// If start fails, revert our local state since we aren't actually recording
+			const { error } = await pendingStartPromise;
+			if (error) {
+				// Start failed (auth, gate, mic error) — revert local state so the
+				// next press starts fresh instead of being eaten by a no-op stop
 				console.error('Start manual recording failed:', error);
 				isRecordingOrStarting = false;
-			} finally {
+				pendingStartPromise = null;
+			} else if (isRecordingOrStarting) {
 				// Clear promise ref if we finished without a stop call intercepting it
 				// (The stop logic might have already set this to null, which is fine)
-				if (isRecordingOrStarting) {
-					pendingStartPromise = null;
-				}
+				pendingStartPromise = null;
 			}
 		}
 	},

--- a/apps/whispering/src/lib/query/commands.ts
+++ b/apps/whispering/src/lib/query/commands.ts
@@ -1,7 +1,7 @@
 import { fromTaggedErr, fromTaggedError, NoteFluxErr } from '$lib/result';
 import type { SelectionContext } from '$lib/services/clipboard/types';
 import * as services from '$lib/services';
-import { checkAnonymousGate } from '$lib/services/anonymous-gate';
+import { checkAnonymousGate, refreshAnonymousGateCache } from '$lib/services/anonymous-gate';
 import { analytics } from '$lib/services/posthog';
 import { auth } from '$lib/stores/auth.svelte';
 import { settings } from '$lib/stores/settings.svelte';
@@ -93,27 +93,43 @@ const startManualRecording = defineMutation({
 	resultMutationFn: async ({ initiatedVia = 'local' }: { initiatedVia?: 'global-shortcut' | 'local' } = {}) => {
 		console.log('🎙️ [COMMAND] startManualRecording called with initiatedVia:', initiatedVia);
 
-		// Capture whether window is focused at recording start
-		// This will be used later during delivery to determine if we should keep window visible
-		if (window.__TAURI_INTERNALS__) {
-			try {
-				const { getCurrentWindow } = await import('@tauri-apps/api/window');
-				wasWindowFocusedAtRecordingStart = await getCurrentWindow().isFocused();
-			} catch (error) {
-				console.error('[COMMAND] Failed to check window focus:', error);
-				wasWindowFocusedAtRecordingStart = false;
-			}
-		} else {
-			wasWindowFocusedAtRecordingStart = false;
-		}
+		// Kick off focus + selection capture immediately (at press time) but do NOT
+		// block on them — the mic start below runs concurrently. They're awaited
+		// after the recorder has started.
+		const isDesktop = !!window.__TAURI_INTERNALS__;
+		const isGlobalShortcut = initiatedVia === 'global-shortcut';
 
-		// Capture selected text + surrounding context at recording start (global shortcut + desktop only)
-		// Stored so delivery can send it to LLM for inline editing
-		if (initiatedVia === 'global-shortcut' && window.__TAURI_INTERNALS__) {
-			selectionContextAtRecordingStart = await services.clipboard.getSelectionWithContext();
-		} else {
-			selectionContextAtRecordingStart = null;
-		}
+		const focusPromise: Promise<boolean> = isDesktop
+			? (async () => {
+					try {
+						const { getCurrentWindow } = await import('@tauri-apps/api/window');
+						return await getCurrentWindow().isFocused();
+					} catch {
+						return false;
+					}
+				})()
+			: Promise.resolve(false);
+
+		const selectionPromise: Promise<SelectionContext | null> = (() => {
+			if (!isDesktop || !isGlobalShortcut) return Promise.resolve(null);
+			if (onboardingStore.isOpen && onboardingStore.currentStep === 'inline-edit') {
+				// DOM selection is read synchronously right now, at press time
+				const el = document.activeElement as HTMLTextAreaElement | null;
+				if (
+					el &&
+					(el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') &&
+					el.selectionStart !== el.selectionEnd
+				) {
+					return Promise.resolve({
+						selectedText: el.value.slice(el.selectionStart!, el.selectionEnd!),
+						contextBefore: el.value.slice(0, el.selectionStart!),
+						contextAfter: el.value.slice(el.selectionEnd!),
+					});
+				}
+				return Promise.resolve(null);
+			}
+			return services.clipboard.getSelectionWithContext().catch(() => null);
+		})();
 
 		// Check authentication first (anonymous users have session from onboarding start)
 		const isAuthenticated = await checkAuthAndShowDialog();
@@ -217,6 +233,11 @@ const startManualRecording = defineMutation({
 		recordingInitiatedVia = initiatedVia;
 		console.info('Recording started');
 		sound.playSoundIfEnabled.execute('manual-start');
+
+		// Mic is already live — settle the press-time captures (they've been running
+		// concurrently with the recorder start above)
+		wasWindowFocusedAtRecordingStart = await focusPromise;
+		selectionContextAtRecordingStart = await selectionPromise;
 
 		// Track recording started in PostHog
 		analytics.trackRecordingStarted('manual');
@@ -798,7 +819,7 @@ async function processRecordingPipeline({
 		// Track text delivery
 		analytics.trackTextDelivered('clipboard');
 
-		// Hide the recording overlay after delivery is complete
+		refreshAnonymousGateCache();
 		await hideRecordingOverlay();
 		return;
 	}
@@ -880,6 +901,6 @@ async function processRecordingPipeline({
 	// Track text delivery for transformed text
 	analytics.trackTextDelivered('clipboard');
 
-	// Hide the recording overlay after delivery is complete
+	refreshAnonymousGateCache();
 	await hideRecordingOverlay();
 }

--- a/apps/whispering/src/lib/services/anonymous-gate.ts
+++ b/apps/whispering/src/lib/services/anonymous-gate.ts
@@ -1,47 +1,49 @@
 import { supabase } from './auth/supabase-client';
 import { auth } from '$lib/stores/auth.svelte';
 
+type GateStatus = { needsSignup: boolean; totalMinutes: number };
+
+let cache: GateStatus | null = null;
+
+async function fetchGateStatus(): Promise<GateStatus | null> {
+	if (!auth.isAuthenticated) return null;
+	if (!auth.isAnonymous) return { needsSignup: false, totalMinutes: 0 };
+
+	const userId = auth.user?.id;
+	if (!userId) return null;
+
+	try {
+		const { data: usageData, error } = await supabase
+			.from('total_usage_limit')
+			.select('total_minutes')
+			.eq('user_id', userId)
+			.single();
+
+		if (error || !usageData) return { needsSignup: false, totalMinutes: 0 };
+
+		const totalMinutes = usageData.total_minutes || 0;
+		return { needsSignup: totalMinutes >= 5, totalMinutes };
+	} catch {
+		return { needsSignup: false, totalMinutes: 0 };
+	}
+}
+
 /**
- * Check if anonymous user has reached the 5-minute gate
- * Returns null if not anonymous or not authenticated
+ * Returns cached gate status instantly. Falls back to network on first call.
+ * Call refreshAnonymousGateCache() after each recording to keep it fresh.
  */
-export async function checkAnonymousGate(): Promise<{
-  needsSignup: boolean;
-  totalMinutes: number;
-} | null> {
-  try {
-    if (!auth.isAuthenticated) {
-      return null;
-    }
+export async function checkAnonymousGate(): Promise<GateStatus | null> {
+	if (cache !== null) return cache;
+	cache = await fetchGateStatus();
+	return cache;
+}
 
-    // Only check gate for anonymous users
-    if (!auth.isAnonymous) {
-      return { needsSignup: false, totalMinutes: 0 };
-    }
-
-    const userId = auth.user?.id;
-    if (!userId) {
-      return null;
-    }
-
-    // Get user's total transcribed minutes
-    const { data: usageData, error: usageError } = await supabase
-      .from('total_usage_limit')
-      .select('total_minutes')
-      .eq('user_id', userId)
-      .single();
-
-    if (usageError || !usageData) {
-      // No usage yet
-      return { needsSignup: false, totalMinutes: 0 };
-    }
-
-    const totalMinutes = usageData.total_minutes || 0;
-    const needsSignup = totalMinutes >= 5;
-
-    return { needsSignup, totalMinutes };
-  } catch (error) {
-    console.error('Error checking anonymous gate:', error);
-    return null;
-  }
+/**
+ * Fire-and-forget refresh after each recording completes.
+ * Updates cache in background so next Fn press is instant.
+ */
+export function refreshAnonymousGateCache(): void {
+	fetchGateStatus().then((result) => {
+		cache = result;
+	});
 }


### PR DESCRIPTION
Recording latency on Fn press came from three stacked sources: the CPAL audio stream being torn down and rebuilt every single press, macOS App Nap throttling the process event loop after a few minutes of idle, and a blocking Supabase network call to check the anonymous gate before the mic could start.

The core fix is stream reuse. The CPAL stream now stays alive after stop_recording and is only rebuilt when the input device changes. This skips the most expensive part of recording startup entirely. BufferSize::Fixed(256) at 16kHz also brings buffer latency down to ~16ms from the default 32-64ms. The WavWriter is swapped per recording while the underlying stream keeps running.

App Nap is prevented via NSProcessInfo beginActivityWithOptions using NSActivityUserInitiated (0x00FFFFFF). Without this, macOS throttles the WebView event loop after ~3 minutes idle, which delays IPC processing even though the global shortcut fires instantly at the OS level. The activity token is intentionally leaked so it lives for the full app lifetime.

On the TypeScript side, anonymous gate status is now cached in memory and refreshed fire-and-forget after each recording completes. The first Fn press of a session still hits the network, but every subsequent press returns instantly from cache. Focus detection and selection context capture also now kick off concurrently with mic start rather than blocking it sequentially.