### PR TITLE
chore: bundle MIT license with Tauri installer

### DIFF
--- a/apps/whispering/src-tauri/tauri.conf.json
+++ b/apps/whispering/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
 		"active": true,
 		"category": "Productivity",
 		"targets": "all",
-		"resources": ["recording-overlay.html", "default.metallib"],
+		"resources": ["recording-overlay.html", "default.metallib", "../../../LICENSE"],
 		"externalBin": ["binaries/qwen3-asr-cli"],
 		"icon": [
 			"icons/32x32.png",


### PR DESCRIPTION
Adds `LICENSE` to `tauri.conf.json` resources so it gets copied into the app bundle at build time.

The MIT license requires the license text be included with distributions. Previously it was missing from the installed app. The file resolves via `../../../LICENSE` from the `src-tauri` directory, pointing to the repo root `LICENSE` file.

Closes #25