### PR TITLE
fix(qwen3-asr): fix first-run daemon timeout and show loading state

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -833,14 +833,17 @@ fn qwen_ensure_daemon(
 
     let mut daemon = QwenASRDaemon { child, stdin, reader: line_rx, model_id: model_id.to_string() };
 
-    // Wait for "READY" with a 60s timeout — generous enough for slow first loads
-    // (Metal kernel compilation) but prevents hanging forever on a stuck sidecar.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    // Wait for "READY" with a 5-minute timeout.
+    // First run on a new machine requires MLX to JIT-compile Metal GPU kernels from
+    // scratch (the pre-built metallib only covers the build machine's GPU generation).
+    // That compilation can take 2-4 minutes on a cold cache. Subsequent runs are fast
+    // because Metal caches compiled shaders in ~/Library/Caches/com.apple.metal/.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(300);
     loop {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
             daemon.child.kill().ok();
-            return Err("Daemon startup timed out (60s) — sidecar may have hung during model load".to_string());
+            return Err("Qwen3-ASR took too long to load (>5 min). Try again — Metal shaders should be cached now.".to_string());
         }
         match daemon.reader.recv_timeout(remaining) {
             Ok(line) if line == "READY" => break,
@@ -849,9 +852,13 @@ fn qwen_ensure_daemon(
                 daemon.child.kill().ok();
                 return Err(format!("Sidecar startup error: {}", line));
             }
-            Err(_) => {
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 daemon.child.kill().ok();
-                return Err("Daemon startup timed out (60s)".to_string());
+                return Err("Qwen3-ASR sidecar crashed during model load. Check Console.app for details.".to_string());
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                daemon.child.kill().ok();
+                return Err("Qwen3-ASR took too long to load (>5 min). Try again — Metal shaders should be cached now.".to_string());
             }
         }
     }

--- a/apps/whispering/src/lib/components/settings/Qwen3ASRModelCard.svelte
+++ b/apps/whispering/src/lib/components/settings/Qwen3ASRModelCard.svelte
@@ -24,6 +24,7 @@
 		| { step: 'not_supported' }
 		| { step: 'not_downloaded' }
 		| { step: 'downloading'; percent: number }
+		| { step: 'warming_up' }
 		| { step: 'downloaded' }
 		| { step: 'deleting' };
 
@@ -74,11 +75,18 @@
 			return;
 		}
 
+		modelStates[modelId] = { step: 'warming_up' };
+
+		try {
+			await services.transcriptions.qwen3asr.preload(modelId);
+		} catch {
+			// Preload failed but model is on disk — user can still try recording
+		}
+
 		modelStates[modelId] = { step: 'downloaded' };
-		toast.success('Model downloaded', {
-			description: 'Qwen3-ASR is ready for on-device transcription.',
+		toast.success('Model ready', {
+			description: 'Qwen3-ASR is loaded and ready for on-device transcription.',
 		});
-		services.transcriptions.qwen3asr.preload(modelId);
 	}
 
 	async function deleteModel(modelId: Qwen3ASRModelId) {
@@ -165,6 +173,16 @@
 								></div>
 							</div>
 							<p class="text-xs text-muted-foreground">Keep the app open until download finishes.</p>
+						</div>
+					{:else if state.step === 'warming_up'}
+						<div class="space-y-2">
+							<div class="flex items-center gap-2 text-sm text-muted-foreground">
+								<Loader2Icon class="size-4 animate-spin shrink-0" />
+								<span>Loading model into memory<span class="text-xs ml-1 text-muted-foreground/70">(first run only — compiling GPU shaders)</span></span>
+							</div>
+							<p class="text-xs text-muted-foreground">
+								This takes 2–4 minutes once. All future loads are instant. Keep the app open.
+							</p>
 						</div>
 					{:else if state.step === 'downloaded'}
 						<div class="space-y-2">

--- a/apps/whispering/src/lib/components/settings/Qwen3ASRModelCard.svelte
+++ b/apps/whispering/src/lib/components/settings/Qwen3ASRModelCard.svelte
@@ -79,14 +79,16 @@
 
 		try {
 			await services.transcriptions.qwen3asr.preload(modelId);
-		} catch {
-			// Preload failed but model is on disk — user can still try recording
+			modelStates[modelId] = { step: 'downloaded' };
+			toast.success('Model ready', {
+				description: 'Qwen3-ASR is loaded and ready for on-device transcription.',
+			});
+		} catch (e) {
+			modelStates[modelId] = { step: 'downloaded' };
+			toast.warning('Model downloaded but failed to load', {
+				description: 'Try pressing Fn to record — it will retry automatically.',
+			});
 		}
-
-		modelStates[modelId] = { step: 'downloaded' };
-		toast.success('Model ready', {
-			description: 'Qwen3-ASR is loaded and ready for on-device transcription.',
-		});
 	}
 
 	async function deleteModel(modelId: Qwen3ASRModelId) {

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -2,10 +2,13 @@ import type { Recording } from '$lib/services/db';
 
 import { NoteFluxErr, type NoteFluxError } from '$lib/result';
 import * as services from '$lib/services';
+import { isQwen3WarmingUp } from '$lib/services/transcription/qwen3-asr';
 import { settings } from '$lib/stores/settings.svelte';
 import { applyDictionary } from '$lib/utils/dictionary';
 import { getGroqApiKey } from '$lib/utils/embedded-keys';
 import { Err, Ok, partitionResults, type Result } from 'wellcrafted/result';
+
+import { toast } from 'svelte-sonner';
 
 import { rpc } from './';
 import { defineMutation, queryClient } from './_client';
@@ -302,11 +305,18 @@ async function transcribeBlob(
 						prompt: settings.value['transcription.prompt'],
 						temperature: settings.value['transcription.temperature'],
 					});
-				case 'Qwen3ASR':
+				case 'Qwen3ASR': {
+					if (isQwen3WarmingUp()) {
+						toast.info('Setting up local model (first run only)', {
+							description: 'Transcription will begin automatically once ready. This takes 2–4 minutes.',
+							duration: 30000,
+						});
+					}
 					return await services.transcriptions.qwen3asr.transcribe(blob, {
 						outputLanguage: settings.value['transcription.outputLanguage'],
 						modelId: settings.value['transcription.qwen3asr.modelId'] as import('$lib/services/transcription/qwen3-asr').Qwen3ASRModelId,
 					});
+				}
 				// case 'OpenAI':
 				// 	return await services.transcriptions.openai.transcribe(blob, {
 				// 		apiKey: settings.value['apiKeys.openai'],

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -306,7 +306,8 @@ async function transcribeBlob(
 						temperature: settings.value['transcription.temperature'],
 					});
 				case 'Qwen3ASR': {
-					if (isQwen3WarmingUp()) {
+					const qwenModelId = settings.value['transcription.qwen3asr.modelId'] as import('$lib/services/transcription/qwen3-asr').Qwen3ASRModelId;
+					if (isQwen3WarmingUp(qwenModelId)) {
 						toast.info('Setting up local model (first run only)', {
 							description: 'Transcription will begin automatically once ready. This takes 2–4 minutes.',
 							duration: 30000,
@@ -314,7 +315,7 @@ async function transcribeBlob(
 					}
 					return await services.transcriptions.qwen3asr.transcribe(blob, {
 						outputLanguage: settings.value['transcription.outputLanguage'],
-						modelId: settings.value['transcription.qwen3asr.modelId'] as import('$lib/services/transcription/qwen3-asr').Qwen3ASRModelId,
+						modelId: qwenModelId,
 					});
 				}
 				// case 'OpenAI':

--- a/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
+++ b/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
@@ -11,10 +11,10 @@ export type Qwen3ASRService = ReturnType<typeof createQwen3ASRService>;
 
 let cachedMacOSMajorVersion: number | null = null;
 const verifiedDownloadedModels = new Set<string>();
-let warmingUp = false;
+const warmingUpModels = new Set<string>();
 
-export function isQwen3WarmingUp(): boolean {
-	return warmingUp;
+export function isQwen3WarmingUp(modelId: string): boolean {
+	return warmingUpModels.has(modelId);
 }
 
 export type Qwen3ASRModelStatus = 'downloaded' | 'not_downloaded';
@@ -132,11 +132,11 @@ export function createQwen3ASRService() {
 		async preload(modelId: Qwen3ASRModelId): Promise<void> {
 			const status = await invoke<Qwen3ASRModelStatus>('qwen3_asr_model_status', { modelId });
 			if (status === 'downloaded') {
-				warmingUp = true;
+				warmingUpModels.add(modelId);
 				try {
 					await invoke('preload_qwen3_asr', { modelId });
 				} finally {
-					warmingUp = false;
+					warmingUpModels.delete(modelId);
 				}
 			}
 		},

--- a/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
+++ b/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
@@ -122,16 +122,13 @@ export function createQwen3ASRService() {
 
 		/**
 		 * Warms up the daemon for a given model so the first transcription is instant.
-		 * Fire-and-forget; errors are ignored.
+		 * Returns a promise that resolves when the daemon is ready (or rejects on error).
 		 */
-		preload(modelId: Qwen3ASRModelId): void {
-			invoke<Qwen3ASRModelStatus>('qwen3_asr_model_status', { modelId })
-				.then((status) => {
-					if (status === 'downloaded') {
-						return invoke('preload_qwen3_asr', { modelId });
-					}
-				})
-				.catch(() => {});
+		async preload(modelId: Qwen3ASRModelId): Promise<void> {
+			const status = await invoke<Qwen3ASRModelStatus>('qwen3_asr_model_status', { modelId });
+			if (status === 'downloaded') {
+				await invoke('preload_qwen3_asr', { modelId });
+			}
 		},
 
 		async transcribe(

--- a/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
+++ b/apps/whispering/src/lib/services/transcription/qwen3-asr.ts
@@ -11,6 +11,11 @@ export type Qwen3ASRService = ReturnType<typeof createQwen3ASRService>;
 
 let cachedMacOSMajorVersion: number | null = null;
 const verifiedDownloadedModels = new Set<string>();
+let warmingUp = false;
+
+export function isQwen3WarmingUp(): boolean {
+	return warmingUp;
+}
 
 export type Qwen3ASRModelStatus = 'downloaded' | 'not_downloaded';
 
@@ -127,7 +132,12 @@ export function createQwen3ASRService() {
 		async preload(modelId: Qwen3ASRModelId): Promise<void> {
 			const status = await invoke<Qwen3ASRModelStatus>('qwen3_asr_model_status', { modelId });
 			if (status === 'downloaded') {
-				await invoke('preload_qwen3_asr', { modelId });
+				warmingUp = true;
+				try {
+					await invoke('preload_qwen3_asr', { modelId });
+				} finally {
+					warmingUp = false;
+				}
 			}
 		},
 

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 			}
 			services.transcriptions.qwen3asr.preload(
 				settings.value['transcription.qwen3asr.modelId'] as import('$lib/services/transcription/qwen3-asr').Qwen3ASRModelId,
-			);
+			).catch(() => {});
 		} else {
 			services.transcriptions.qwen3asr.shutdown();
 		}

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 			}
 			services.transcriptions.qwen3asr.preload(
 				settings.value['transcription.qwen3asr.modelId'] as import('$lib/services/transcription/qwen3-asr').Qwen3ASRModelId,
-			).catch(() => {});
+			).catch((e) => console.error('[qwen3-asr] background warmup failed:', e));
 		} else {
 			services.transcriptions.qwen3asr.shutdown();
 		}


### PR DESCRIPTION
On a fresh machine, qwen3-asr-cli fails to start within the previous 60s timeout because Apple MLX must JIT-compile Metal GPU shaders from scratch. The pre-built default.metallib only covers the exact GPU architecture of the build machine — users on a different chip generation (e.g. M4 when built on M2) fall through to full JIT compilation which takes 2–4 minutes. This caused every first-run transcription attempt to fail with "Daemon timed out after 60 seconds."

The timeout is increased to 5 minutes. The Disconnected error case (daemon crashed) is now distinguished from a plain timeout so the two failure modes show different, actionable messages instead of the same generic timeout error.

On the UX side, the model card now enters a warming_up state after download completes and awaits preload() before transitioning to the downloaded green state. The user sees a spinner with "Loading model into memory (first run only — compiling GPU shaders)" and knows to keep the app open. If they navigate away and press Fn while the daemon is still loading, a 30-second toast explains that transcription will begin automatically once the model is ready.

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-model warm-up state with a spinner and “first run/compiling GPU shaders” guidance.
  - Added first-run notifications to let users know initial transcription may take longer.
- **Bug Fixes**
  - Improved warm-up flow: the model only transitions to ready after preparation completes, with clearer success/warning toasts.
  - Enhanced macOS ASR daemon startup to wait longer for readiness and report clearer “crashed during model load” errors.
  - Prevented warm-up failures from causing unhandled promise rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->