### PR TITLE
fix(qwen3-asr): redirect load-time stdout to stderr so MLX errors surface

### DIFF
--- a/apps/whispering/src-tauri/qwen3-asr-cli/Sources/QwenASRCLI/main.swift
+++ b/apps/whispering/src-tauri/qwen3-asr-cli/Sources/QwenASRCLI/main.swift
@@ -145,7 +145,12 @@ func loadAudio(from path: String) throws -> (samples: [Float], sampleRate: Int) 
 Task {
     // Keep realStdoutFd outside do{} so catch{} can write the error back to Rust.
     let realStdoutFd = dup(STDOUT_FILENO)
-    freopen("/dev/null", "w", stdout)
+    // Route the model's stdout chatter to stderr (not /dev/null) during load, so the
+    // READY/OK/ERR protocol channel (realStdoutFd) stays clean while any load failure
+    // stays visible. MLX's C error handler prints to stdout then exit(-1) — bypassing
+    // our Swift catch{} entirely — so /dev/null would silently swallow the real error.
+    // Sending it to stderr (which Rust inherits) surfaces it in Console.app instead.
+    dup2(STDERR_FILENO, STDOUT_FILENO)
 
     func writeLine(_ s: String) {
         var line = s + "\n"


### PR DESCRIPTION
MLX's C error handler (`mlx_error_handler_default_` in `mlx-c/mlx/c/error.cpp`) calls `printf()` then `exit(-1)`. Since `printf` writes to stdout (fd 1), and we previously redirected stdout to `/dev/null` during model load to keep the READY/OK/ERR protocol pipe clean, any MLX load failure was silently swallowed: process exited 255 with nothing on stderr, nothing in crash reports, and nothing on the protocol pipe.

This replaces `freopen("/dev/null", "w", stdout)` with `dup2(STDERR_FILENO, STDOUT_FILENO)`. Load-time stdout chatter (and any MLX error) now goes to stderr instead. Rust inherits stderr from the sidecar, so errors appear in Console.app. The protocol channel (`realStdoutFd`) is a saved `dup` and is unaffected — the `dup2` back to `STDOUT_FILENO` still runs before writing `READY` on the success path.

This was the root reason the "Failed to load the default metallib" error went undetected for several debug cycles: the error existed and was specific, but we were piping it into `/dev/null` and looking at stderr (empty) and crash reports (none, because `exit(-1)` is a clean exit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of model-loading errors so failures from the speech recognition engine are reported to the application instead of being silently suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->