### PR TITLE
perf(qwen3-asr): always use greedy fast path for long recordings

### DIFF
--- a/apps/whispering/src-tauri/qwen3-asr-cli/Sources/QwenASRCLI/main.swift
+++ b/apps/whispering/src-tauri/qwen3-asr-cli/Sources/QwenASRCLI/main.swift
@@ -181,7 +181,11 @@ Task {
 
             do {
                 let (samples, sampleRate) = try loadAudio(from: audioPath)
-                let text = model.transcribe(audio: samples, sampleRate: sampleRate, language: language)
+                // longInputNoRepeatNgramSize: 0 keeps the greedy fast path (double-buffered
+                // asyncEval) active for recordings >15s. The default of 3 auto-escalates to
+                // generateSlow, which does a blocking CPU-GPU sync per token and has no overlap.
+                let options = Qwen3DecodingOptions(language: language, longInputNoRepeatNgramSize: 0)
+                let text = model.transcribe(audio: samples, sampleRate: sampleRate, options: options)
                 writeLine("OK:" + text.trimmingCharacters(in: .whitespacesAndNewlines))
             } catch {
                 writeLine("ERR:" + error.localizedDescription)


### PR DESCRIPTION
Recordings longer than 15 seconds were hitting speech-swift's slow decode path, causing per-token CPU-GPU stalls that made the transcription feel laggy.

Speech-swift's default `Qwen3DecodingOptions` has `longInputNoRepeatNgramSize: 3`. When audio exceeds `longInputThresholdSeconds` (15s), `adaptedFor()` bumps `noRepeatNgramSize` to 3, which causes `isGreedyFastPath()` to return false and routes to `generateSlow`. That function pulls the full logits tensor to CPU on every decoder token to run n-gram checks — blocking CPU-GPU overlap entirely.

The fix passes `longInputNoRepeatNgramSize: 0` explicitly, which disables the auto-escalation. `generateGreedyAsyncEval` stays active regardless of recording length: GPU step N+1 overlaps CPU step N via double-buffered asyncEval, cutting per-token latency significantly on long clips.

The tradeoff is no n-gram repetition blocking on long recordings, but ASR models are audio-guided and rarely repeat in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription handling for long recordings.
  * Preserved the existing success and error responses while using updated decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->