### PR TITLE
fix(qwen3-asr): kill daemon on app exit to free wired Metal memory

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -571,7 +571,11 @@ pub async fn run() {
                 let state: tauri::State<QwenASRState> = handler.state();
                 let arc = state.0.clone();
                 drop(state);
-                if let Some(mut daemon) = arc.lock().ok().and_then(|mut g| g.take()) {
+                let daemon = match arc.lock() {
+                    Ok(mut g) => g.take(),
+                    Err(e) => e.into_inner().take(),
+                };
+                if let Some(mut daemon) = daemon {
                     let _ = daemon.child.kill();
                     let _ = daemon.child.wait();
                 }

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -563,6 +563,19 @@ pub async fn run() {
     
     app.run(|handler, event| match event {
         tauri::RunEvent::Exit { .. } => {
+            // Kill the qwen daemon before exit. std::process::exit() (called by
+            // handler.exit()) bypasses Rust destructors, so without this the daemon
+            // becomes an orphan holding 2-3GB of wired Metal memory after the app closes.
+            #[cfg(target_os = "macos")]
+            {
+                let state: tauri::State<QwenASRState> = handler.state();
+                let arc = state.0.clone();
+                drop(state);
+                if let Some(mut daemon) = arc.lock().ok().and_then(|mut g| g.take()) {
+                    let _ = daemon.child.kill();
+                    let _ = daemon.child.wait();
+                }
+            }
             let _ = handler.track_event("app_exited", None);
             handler.flush_events_blocking();
         }


### PR DESCRIPTION
The qwen3-asr-cli daemon was becoming an orphan process every time the app closed normally, holding 2-3GB of wired Metal memory indefinitely.

Root cause: Tauri's `handler.exit()` calls `std::process::exit()` internally, which bypasses Rust destructors. The `QwenASRDaemon` struct has no `Drop` impl, so its `child: std::process::Child` was never killed — it became orphaned under launchd, retaining all wired Metal memory from the loaded model. The user could close NoteFlux and the daemon would keep running invisibly, starving the system of unified memory.

The fix kills the daemon explicitly in `RunEvent::Exit`, before the process exits. The existing startup `pkill -f qwen3-asr-cli` remains as a fallback for crash and force-quit cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS shutdown behavior by ensuring the speech recognition subprocess is explicitly terminated and fully waited on during app exit.
  * Prevents background cleanup issues that could leave processes running after shutdown, reducing the risk of lingering GPU or system resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->