### PR TITLE
fix(delivery): inline edit takes priority over transformation when text is selected

### DIFF
--- a/apps/whispering/src/lib/query/commands.ts
+++ b/apps/whispering/src/lib/query/commands.ts
@@ -806,8 +806,11 @@ async function processRecordingPipeline({
 	const transformationId =
 		settings.value['transformations.selectedTransformationId'];
 
-	// If no transformation is selected, deliver the raw transcription result and exit
-	if (!transformationId) {
+	// If no transformation is selected, or the user has text selected (inline edit takes
+	// priority over transformation — intent is "edit this text", not "transform my speech"),
+	// deliver via transcription path which handles the selectionContext inline-edit flow.
+	const hasSelectionContext = !!selectionContext?.selectedText?.trim();
+	if (!transformationId || hasSelectionContext) {
 		await delivery.deliverTranscriptionResult.execute({
 			text: transcribedText,
 			toastId: transcribeToastId,


### PR DESCRIPTION
When a transformation was active and the user had text selected in an external app, the `selectionContext` was silently dropped. The pipeline entered the transformation path, ran the LLM transform on the raw transcription, and pasted the result verbatim — the inline-edit feature never fired.

The user experience: select text → record a voice instruction → spoken words paste as-is instead of the selected text being edited by the instruction.

The root cause is that `processRecordingPipeline` checked `!transformationId` to decide whether to call `deliverTranscriptionResult` (which handles `selectionContext` inline edit). When a transformation was active, it skipped straight to the transformation path and never passed `selectionContext` to delivery.

The fix is a one-line condition change: check `hasSelectionContext` alongside `!transformationId`. When the user has text selected, route through `deliverTranscriptionResult` with `selectionContext` regardless of whether a transformation is active. Inline edit intent — "edit this selected text using my voice instruction" — takes priority over post-processing transformation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording transcription handling when text is selected.
  * Selected text now takes priority over transformation processing.
  * Transcriptions without a transformation continue through the standard flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->