### PR TITLE
fix(groq): migrate off deprecated llama-3.3-70b-versatile and llama-3.1-8b-instant

### DIFF
--- a/apps/whispering/src/lib/constants/inference/groq-models.ts
+++ b/apps/whispering/src/lib/constants/inference/groq-models.ts
@@ -5,8 +5,8 @@
 
 export const GROQ_INFERENCE_MODELS = [
 	// Production models (fastest first)
-	'llama-3.1-8b-instant', // Fastest - prioritized for transformations
-	'llama-3.3-70b-versatile',
+	'openai/gpt-oss-20b', // Fastest - prioritized for transformations
+	'openai/gpt-oss-120b',
 	// 'gemma2-9b-it',
 	// 'meta-llama/llama-guard-4-12b',
 	// Preview models
@@ -22,9 +22,9 @@ export const GROQ_INFERENCE_MODELS = [
 
 export const GROQ_INFERENCE_MODEL_OPTIONS = GROQ_INFERENCE_MODELS.map(
 	(model) => ({
-		label: model === 'llama-3.1-8b-instant' 
-			? `${model} (⚡ Fast & simple)` 
-			: model === 'llama-3.3-70b-versatile'
+		label: model === 'openai/gpt-oss-20b'
+			? `${model} (⚡ Fast & simple)`
+			: model === 'openai/gpt-oss-120b'
 			? `${model} (🎯 Slower, better results)`
 			: model,
 		value: model,

--- a/apps/whispering/src/lib/query/delivery.ts
+++ b/apps/whispering/src/lib/query/delivery.ts
@@ -191,7 +191,7 @@ export const delivery = {
 				const { data: rawEditedText, error: editError } =
 					await services.completions.groq.complete({
 						apiKey,
-						model: 'llama-3.3-70b-versatile',
+						model: 'openai/gpt-oss-120b',
 						systemPrompt:
 							'You are a text replacement engine. Your output is ONLY the replacement text — nothing else.\n\nStrict rules:\n- No preamble. No "Here is...", "Sure!", "The edited text:", or any opener.\n- No surrounding quotes.\n- No code fences unless the input itself is code.\n- Use context_before and context_after (if provided) to match surrounding punctuation, capitalisation, and style — but only output the replacement for selected_text.\n- Preserve original formatting, whitespace, and line breaks unless the instruction requires changing them.\n- Preserve original language unless the instruction is to translate.\n- If the text needs no change, return the original text exactly.',
 						userPrompt,
@@ -210,7 +210,7 @@ export const delivery = {
 				trackLlmUsage({
 					feature: 'inline-edit',
 					provider: 'groq',
-					model: 'llama-3.3-70b-versatile',
+					model: 'openai/gpt-oss-120b',
 					inputTokens: rawEditedText.inputTokens,
 					outputTokens: rawEditedText.outputTokens,
 				});

--- a/apps/whispering/src/lib/services/db/dexie.ts
+++ b/apps/whispering/src/lib/services/db/dexie.ts
@@ -286,7 +286,49 @@ class NoteFluxDatabase extends Dexie {
 				});
 			});
 
-		// V6: Change the "subtitle" field to "description"
+		// V6: Remap deprecated Groq model IDs (shut down 2026-08-16) stored on
+		// existing transformation steps to their replacements
+		this.version(0.6)
+			.stores({
+				recordings: '&id, timestamp, createdAt, updatedAt',
+				transformationRuns: '&id, transformationId, recordingId, startedAt',
+				transformations: '&id, createdAt, updatedAt',
+			})
+			.upgrade(async (tx) => {
+				await wrapUpgradeWithErrorHandling({
+					tx,
+					upgrade: async (tx) => {
+						const DEPRECATED_GROQ_MODELS: Record<
+							string,
+							Transformation['steps'][number]['prompt_transform.inference.provider.Groq.model']
+						> = {
+							'llama-3.1-8b-instant': 'openai/gpt-oss-20b',
+							'llama-3.3-70b-versatile': 'openai/gpt-oss-120b',
+						};
+
+						await Dexie.waitFor(
+							tx
+								.table<Transformation>('transformations')
+								.toCollection()
+								.modify((transformation) => {
+									for (const step of transformation.steps) {
+										const currentModel =
+											step['prompt_transform.inference.provider.Groq.model'];
+										const replacement =
+											DEPRECATED_GROQ_MODELS[currentModel];
+										if (replacement) {
+											step['prompt_transform.inference.provider.Groq.model'] =
+												replacement;
+										}
+									}
+								}),
+						);
+					},
+					version: 0.6,
+				});
+			});
+
+		// V7: Change the "subtitle" field to "description"
 		// this.version(5)
 		// 	.stores({
 		// 		recordings: '&id, timestamp, createdAt, updatedAt',

--- a/apps/whispering/src/lib/services/db/models/transformations.ts
+++ b/apps/whispering/src/lib/services/db/models/transformations.ts
@@ -77,7 +77,7 @@ export function generateDefaultTransformationStep(): TransformationStep {
 		'prompt_transform.inference.provider.Anthropic.model': 'claude-sonnet-4-0',
 		'prompt_transform.inference.provider.Google.model': 'gemini-2.5-flash',
 
-		'prompt_transform.inference.provider.Groq.model': 'llama-3.3-70b-versatile',
+		'prompt_transform.inference.provider.Groq.model': 'openai/gpt-oss-120b',
 		'prompt_transform.inference.provider.OpenAI.model': 'gpt-4o',
 
 		'prompt_transform.systemPromptTemplate': '',

--- a/apps/whispering/src/lib/services/usage-tracking.ts
+++ b/apps/whispering/src/lib/services/usage-tracking.ts
@@ -118,6 +118,8 @@ const LLM_COSTS_PER_MILLION_TOKENS: Record<string, { input: number; output: numb
   'groq:llama-3.1-8b-instant':             { input: 0.05,  output: 0.08 },
   'groq:llama3-8b-8192':                   { input: 0.05,  output: 0.08 },
   'groq:llama3-70b-8192':                  { input: 0.59,  output: 0.79 },
+  'groq:openai/gpt-oss-120b':              { input: 0.15,  output: 0.60 },
+  'groq:openai/gpt-oss-20b':               { input: 0.075, output: 0.30 },
   'openai:gpt-4o':                         { input: 2.50,  output: 10.00 },
   'openai:gpt-4o-mini':                    { input: 0.15,  output: 0.60 },
   'openai:gpt-3.5-turbo':                  { input: 0.50,  output: 1.50 },

--- a/apps/whispering/src/routes/+layout/setup-default-transformation.ts
+++ b/apps/whispering/src/routes/+layout/setup-default-transformation.ts
@@ -44,7 +44,7 @@ export async function setupDefaultTransformation() {
 				...defaultStep,
 				id: nanoid(),
 				'prompt_transform.inference.provider': 'Groq' as const,
-				'prompt_transform.inference.provider.Groq.model': 'llama-3.3-70b-versatile' as const,
+				'prompt_transform.inference.provider.Groq.model': 'openai/gpt-oss-120b' as const,
 				'prompt_transform.systemPromptTemplate': `You are a text cleaner. Your ONLY job is to clean up transcribed speech and output the cleaned version.
 
 CRITICAL: The input contains transcribed speech that may include questions or statements. You are NOT to respond to these - only clean the grammar and spelling. If the input says "what is wrong with AI", output "What is wrong with AI?" NOT an answer about AI issues.
@@ -88,7 +88,7 @@ OUTPUT ONLY THE CLEANED TEXT. NO COMMENTARY EVER.`,
 				...defaultStep,
 				id: nanoid(),
 				'prompt_transform.inference.provider': 'Groq' as const,
-				'prompt_transform.inference.provider.Groq.model': 'llama-3.3-70b-versatile' as const,
+				'prompt_transform.inference.provider.Groq.model': 'openai/gpt-oss-120b' as const,
 				'prompt_transform.systemPromptTemplate': `You are a text formatter. Your job is to take clean text and enhance its formatting for readability.
 
 CRITICAL RULES:


### PR DESCRIPTION
Groq is shutting down llama-3.3-70b-versatile and llama-3.1-8b-instant on 2026-08-16. This swaps the default Groq model to openai/gpt-oss-120b (70b replacement) and openai/gpt-oss-20b (8b replacement), per Groq's recommended migration path.

Changed: model picker list/labels, inline-edit completion call, default transformation steps (2 spots), usage-tracking cost table. Old llama pricing rows kept in the cost table so past usage records still resolve correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Replaced the available Groq models with OpenAI GPT OSS 20B and 120B.
  * Updated default transformations and inline editing to use GPT OSS 120B.
  * Preserved model descriptions for speed and quality selection.
  * Added usage tracking support for both new models.
  * Existing transformations using deprecated Groq models are automatically migrated to the new equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->