### PR TITLE
feat(glance): add opt-in frontmost app detection

### DIFF
--- a/apps/whispering/src-tauri/src/frontmost_app.rs
+++ b/apps/whispering/src-tauri/src/frontmost_app.rs
@@ -1,0 +1,50 @@
+use cocoa::base::{id, nil};
+use cocoa::foundation::NSString;
+use objc::runtime::Class;
+use objc::{msg_send, sel, sel_impl};
+use serde::Serialize;
+use std::ffi::CStr;
+
+#[derive(Serialize)]
+pub struct FrontmostAppInfo {
+    bundle_id: Option<String>,
+    name: Option<String>,
+}
+
+/// Fetch the frontmost app's bundle identifier and display name via
+/// NSWorkspace. No Accessibility/Screen Recording permission required —
+/// this is a plain Cocoa API.
+#[tauri::command]
+pub fn get_frontmost_app() -> Result<FrontmostAppInfo, String> {
+    unsafe {
+        let workspace_class = match Class::get("NSWorkspace") {
+            Some(class) => class,
+            None => return Err("NSWorkspace class not found".to_string()),
+        };
+
+        let workspace: id = msg_send![workspace_class, sharedWorkspace];
+        let frontmost_app: id = msg_send![workspace, frontmostApplication];
+        if frontmost_app == nil {
+            return Err("No frontmost application".to_string());
+        }
+
+        let bundle_id_ns: id = msg_send![frontmost_app, bundleIdentifier];
+        let name_ns: id = msg_send![frontmost_app, localizedName];
+
+        Ok(FrontmostAppInfo {
+            bundle_id: ns_string_to_string(bundle_id_ns),
+            name: ns_string_to_string(name_ns),
+        })
+    }
+}
+
+unsafe fn ns_string_to_string(ns_str: id) -> Option<String> {
+    if ns_str == nil {
+        return None;
+    }
+    let utf8_ptr = ns_str.UTF8String();
+    if utf8_ptr.is_null() {
+        return None;
+    }
+    Some(CStr::from_ptr(utf8_ptr).to_string_lossy().into_owned())
+}

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -5,6 +5,9 @@ mod accessibility;
 #[cfg(target_os = "macos")]
 mod microphone;
 
+#[cfg(target_os = "macos")]
+mod frontmost_app;
+
 // Keyboard handling module (Fn key support)
 mod keyboard;
 
@@ -14,6 +17,9 @@ use accessibility::{get_selection_with_context, is_macos_accessibility_enabled, 
 
 #[cfg(target_os = "macos")]
 use microphone::{is_macos_microphone_enabled, request_macos_microphone_permission};
+
+#[cfg(target_os = "macos")]
+use frontmost_app::get_frontmost_app;
 
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder, menu::{Menu, MenuItem}, tray::{TrayIconBuilder, TrayIconEvent}};
 use tauri_plugin_aptabase::EventTracker;
@@ -420,6 +426,7 @@ pub async fn run() {
         get_selection_with_context,
         is_macos_microphone_enabled,
         request_macos_microphone_permission,
+        get_frontmost_app,
         // Audio recorder commands
         get_current_recording_id,
         enumerate_recording_devices,

--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -7,16 +7,15 @@ import { settings } from '$lib/stores/settings.svelte';
 import type { ShortcutTriggerState } from './services/_shortcut-trigger-state';
 
 // Only checks which app is frontmost when the user has explicitly opted
-// into Glance — the app must never fetch this without that consent.
+// into Glance — the app must never fetch this without that consent, and
+// never logs the result (app identity is privacy-sensitive).
 // get_frontmost_app is only registered on macOS, so skip elsewhere rather
 // than firing an invoke that's guaranteed to fail.
-function logFrontmostApp() {
+function captureFrontmostApp() {
 	if (!settings.value['glance.enabled']) return;
 	if (services.os.type() !== 'macos') return;
 
-	invoke('get_frontmost_app')
-		.then((info) => console.log('[FrontmostApp]', info))
-		.catch((error) => console.log('[FrontmostApp] error:', error));
+	invoke('get_frontmost_app').catch(() => {});
 }
 
 type SatisfiedCommand = {
@@ -132,7 +131,7 @@ export const globalCommandCallbacks: CommandCallbacks = {
 			await rpc.commands.stopManualRecording.execute(undefined);
 		} else {
 			// --- START LOGIC (Press) ---
-			logFrontmostApp();
+			captureFrontmostApp();
 			// Immediately mark as active so next call (Release) knows to stop
 			isRecordingOrStarting = true;
 
@@ -156,7 +155,7 @@ export const globalCommandCallbacks: CommandCallbacks = {
 		}
 	},
 	toggleManualRecording: () => {
-		logFrontmostApp();
+		captureFrontmostApp();
 		return rpc.commands.toggleManualRecording.execute({
 			initiatedVia: 'global-shortcut',
 		});

--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -1,6 +1,23 @@
+import { invoke } from '@tauri-apps/api/core';
+
+import * as services from '$lib/services';
 import { rpc } from '$lib/query';
+import { settings } from '$lib/stores/settings.svelte';
 
 import type { ShortcutTriggerState } from './services/_shortcut-trigger-state';
+
+// Only checks which app is frontmost when the user has explicitly opted
+// into Glance — the app must never fetch this without that consent.
+// get_frontmost_app is only registered on macOS, so skip elsewhere rather
+// than firing an invoke that's guaranteed to fail.
+function logFrontmostApp() {
+	if (!settings.value['glance.enabled']) return;
+	if (services.os.type() !== 'macos') return;
+
+	invoke('get_frontmost_app')
+		.then((info) => console.log('[FrontmostApp]', info))
+		.catch((error) => console.log('[FrontmostApp] error:', error));
+}
 
 type SatisfiedCommand = {
 	callback: () => void;
@@ -115,6 +132,7 @@ export const globalCommandCallbacks: CommandCallbacks = {
 			await rpc.commands.stopManualRecording.execute(undefined);
 		} else {
 			// --- START LOGIC (Press) ---
+			logFrontmostApp();
 			// Immediately mark as active so next call (Release) knows to stop
 			isRecordingOrStarting = true;
 
@@ -137,10 +155,12 @@ export const globalCommandCallbacks: CommandCallbacks = {
 			}
 		}
 	},
-	toggleManualRecording: () =>
-		rpc.commands.toggleManualRecording.execute({
+	toggleManualRecording: () => {
+		logFrontmostApp();
+		return rpc.commands.toggleManualRecording.execute({
 			initiatedVia: 'global-shortcut',
-		}),
+		});
+	},
 	cancelManualRecording: () => {
 		// Reset local state when cancelling
 		isRecordingOrStarting = false;

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -95,6 +95,11 @@ export const settingsSchema = z.object({
 	// Notifications settings
 	'notifications.enabled': z.boolean().default(false),
 
+	// Glance settings — off by default; when on, lets NoteFlux see which app
+	// is frontmost (and later, screen content) to give better answers.
+	// Nothing is ever saved to disk.
+	'glance.enabled': z.boolean().default(false),
+
 	// Onboarding settings
 	'onboarding.hasSeenWelcome': z.boolean().default(false),
 	'onboarding.pasteTestCompleted': z.boolean().default(false),

--- a/apps/whispering/src/routes/(config)/settings/SidebarNav.svelte
+++ b/apps/whispering/src/routes/(config)/settings/SidebarNav.svelte
@@ -17,6 +17,7 @@
 			activePathPrefix: '/settings/shortcuts',
 			href: '/settings/shortcuts/global', // Direct link to global shortcuts (local shortcuts disabled)
 		},
+		{ title: 'Glance', href: '/settings/glance' },
 		// { title: 'Privacy & Analytics', href: '/settings/analytics' },
 	] satisfies {
 		/**

--- a/apps/whispering/src/routes/(config)/settings/glance/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/glance/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { settings } from '$lib/stores/settings.svelte';
+	import { Badge } from '$lib/ui/badge';
+	import * as Card from '$lib/ui/card';
+	import { Label } from '$lib/ui/label';
+	import { Switch } from '$lib/ui/switch';
+
+	function handleGlanceToggle(checked: boolean) {
+		settings.updateKey('glance.enabled', checked);
+	}
+</script>
+
+<div class="space-y-8">
+	<!-- Page Header -->
+	<div class="space-y-2">
+		<div class="flex items-center gap-3">
+			<h3 class="text-xl font-semibold tracking-tight">Glance</h3>
+			{#if settings.value['glance.enabled']}
+				<Badge variant="outline" class="text-xs text-green-700 dark:text-green-400 border-green-200 dark:border-green-400/30">
+					Enabled
+				</Badge>
+			{:else}
+				<Badge variant="outline" class="text-xs text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-400/30">
+					Disabled
+				</Badge>
+			{/if}
+		</div>
+		<p class="text-sm text-muted-foreground max-w-2xl">
+			Let NoteFlux see which app you're in so it can give better answers. Nothing is ever saved.
+		</p>
+	</div>
+
+	<!-- Main Toggle Section -->
+	<Card.Root class="transition-colors duration-200">
+		<Card.Content>
+			<div class="flex items-start justify-between gap-4">
+				<div class="space-y-2 flex-1">
+					<Label for="glance-toggle" class="text-base font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+						Use app context for better accuracy
+					</Label>
+					<p class="text-sm text-muted-foreground leading-relaxed">
+						When you press Fn, NoteFlux checks which app is frontmost to tailor its response — for example, a more formal tone in Mail, code-aware output in an editor.
+					</p>
+				</div>
+				<Switch
+					id="glance-toggle"
+					checked={settings.value['glance.enabled']}
+					onCheckedChange={handleGlanceToggle}
+					class="shrink-0"
+				/>
+			</div>
+		</Card.Content>
+	</Card.Root>
+
+	<!-- Data Collection Information -->
+	<div class="grid gap-4 md:grid-cols-2">
+		<Card.Root class="border-green-100 dark:border-green-900/20">
+			<Card.Header>
+				<Card.Title class="text-sm font-medium text-green-700 dark:text-green-400 flex items-center gap-2">
+					<div class="w-2 h-2 bg-green-500 rounded-full"></div>
+					What we check
+				</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<ul class="text-sm text-muted-foreground space-y-1.5 leading-relaxed">
+					<li class="flex items-start gap-2">
+						<span class="text-green-500 mt-1">•</span>
+						<span>The name of the app you're currently using</span>
+					</li>
+					<li class="flex items-start gap-2">
+						<span class="text-green-500 mt-1">•</span>
+						<span>Checked once, only when you press Fn</span>
+					</li>
+				</ul>
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root class="border-amber-100 dark:border-amber-900/20">
+			<Card.Header>
+				<Card.Title class="text-sm font-medium text-amber-700 dark:text-amber-400 flex items-center gap-2">
+					<div class="w-2 h-2 bg-amber-500 rounded-full"></div>
+					Never saved
+				</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<ul class="text-sm text-muted-foreground space-y-1.5 leading-relaxed">
+					<li class="flex items-start gap-2">
+						<span class="text-amber-500 mt-1">•</span>
+						<span>No screenshots or screen content are stored</span>
+					</li>
+					<li class="flex items-start gap-2">
+						<span class="text-amber-500 mt-1">•</span>
+						<span>Nothing is uploaded unless you're actively asking a question</span>
+					</li>
+					<li class="flex items-start gap-2">
+						<span class="text-amber-500 mt-1">•</span>
+						<span>Turned off entirely by default — this is opt-in only</span>
+					</li>
+				</ul>
+			</Card.Content>
+		</Card.Root>
+	</div>
+
+	<!-- Status Footer -->
+	<div class="flex items-center gap-2 text-xs">
+		{#if settings.value['glance.enabled']}
+			<div class="flex items-center gap-2 text-green-700 dark:text-green-400">
+				<div class="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
+				<span class="font-medium">Glance active</span>
+				<span class="text-muted-foreground">• Changes take effect immediately</span>
+			</div>
+		{:else}
+			<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+				<div class="w-2 h-2 bg-amber-500 rounded-full"></div>
+				<span class="font-medium">Glance disabled</span>
+				<span class="text-muted-foreground">• NoteFlux never checks which app you're in</span>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/apps/whispering/src/routes/(config)/settings/glance/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/glance/+page.svelte
@@ -4,10 +4,6 @@
 	import * as Card from '$lib/ui/card';
 	import { Label } from '$lib/ui/label';
 	import { Switch } from '$lib/ui/switch';
-
-	function handleGlanceToggle(checked: boolean) {
-		settings.updateKey('glance.enabled', checked);
-	}
 </script>
 
 <div class="space-y-8">
@@ -26,7 +22,7 @@
 			{/if}
 		</div>
 		<p class="text-sm text-muted-foreground max-w-2xl">
-			Let NoteFlux see which app you're in so it can give better answers. Nothing is ever saved.
+			Early foundation for app-aware features. Right now it only detects which app you're in — it doesn't change NoteFlux's behavior yet. Nothing is ever saved.
 		</p>
 	</div>
 
@@ -36,16 +32,16 @@
 			<div class="flex items-start justify-between gap-4">
 				<div class="space-y-2 flex-1">
 					<Label for="glance-toggle" class="text-base font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-						Use app context for better accuracy
+						Detect which app you're using
 					</Label>
 					<p class="text-sm text-muted-foreground leading-relaxed">
-						When you press Fn, NoteFlux checks which app is frontmost to tailor its response — for example, a more formal tone in Mail, code-aware output in an editor.
+						When you press Fn, NoteFlux checks which app is frontmost. This doesn't change your results yet — it's groundwork for app-aware features coming later, like a more formal tone in Mail or code-aware output in an editor.
 					</p>
 				</div>
 				<Switch
 					id="glance-toggle"
 					checked={settings.value['glance.enabled']}
-					onCheckedChange={handleGlanceToggle}
+					onCheckedChange={(checked) => settings.updateKey('glance.enabled', checked)}
 					class="shrink-0"
 				/>
 			</div>

--- a/apps/whispering/src/routes/(config)/settings/glance/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/glance/+page.svelte
@@ -86,7 +86,7 @@
 					</li>
 					<li class="flex items-start gap-2">
 						<span class="text-amber-500 mt-1">•</span>
-						<span>Nothing is uploaded unless you're actively asking a question</span>
+						<span>Nothing leaves your device — checked locally, never sent anywhere</span>
 					</li>
 					<li class="flex items-start gap-2">
 						<span class="text-amber-500 mt-1">•</span>


### PR DESCRIPTION
Adds the groundwork for app-aware behavior: a get_frontmost_app Tauri command (NSWorkspace, macOS-only, no extra OS permission required) that identifies which app is frontmost at the moment Fn is pressed.

The whole thing is gated behind a new glance.enabled setting, off by default, with its own Settings page (Settings → Glance) that explains what's checked and confirms nothing is ever saved to disk. Off means the app never even calls this, not just that it ignores the result. There's a platform guard too, since the command only exists on macOS — on other platforms the check is skipped rather than firing a call that's guaranteed to fail.

Validated live against several real apps (Notes, Cursor) — correctly returns bundle ID and display name on every Fn press with no added latency.

Right now the captured app identity is only logged, not consumed anywhere. That's intentional — the actual behavior this unlocks (auto-selecting transformations by app category, tailoring system prompts, model routing) is real product logic that deserves its own PR and review, not bundled into "can we read the frontmost app at all."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Glance setting with a dedicated configuration page.
  * Added macOS support for detecting the active application during recording actions.
  * Added clear status messaging explaining Glance’s behavior and data handling.
  * Added Glance to the settings navigation.

* **Bug Fixes**
  * Recording shortcuts now consistently check the active application when Glance is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->